### PR TITLE
Update to match Automerge performance branch

### DIFF
--- a/automerge-backend-wasm/encoding.js
+++ b/automerge-backend-wasm/encoding.js
@@ -501,12 +501,16 @@ class RLEEncoder extends Encoder {
     this.lastValue = undefined
     this.count = 0
     this.literal = []
+    this.onlyNulls = true
   }
 
   /**
    * Appends a new value to the sequence.
    */
   appendValue(value) {
+    if (value !== null && value !== undefined) {
+      this.onlyNulls = false
+    }
     if (this.lastValue === undefined) {
       this.lastValue = value
     }
@@ -537,6 +541,9 @@ class RLEEncoder extends Encoder {
     this.count = (value === undefined ? 0 : 1)
   }
 
+  /**
+   * Private method, do not call from outside the class.
+   */
   appendRawValue(value) {
     if (this.type === 'int') {
       this.appendInt53(value)
@@ -583,6 +590,8 @@ class RLEDecoder extends Decoder {
    * Returns the next value (or null) in the sequence.
    */
   readValue() {
+    if (this.done) return null
+
     if (this.count === 0) {
       this.count = this.readInt53()
       if (this.count > 0) {
@@ -606,6 +615,9 @@ class RLEDecoder extends Decoder {
     }
   }
 
+  /**
+   * Private method, do not call from outside the class.
+   */
   readRawValue() {
     if (this.type === 'int') {
       return this.readInt53()

--- a/automerge-backend-wasm/index.js
+++ b/automerge-backend-wasm/index.js
@@ -1,5 +1,4 @@
 let Backend = require("./pkg")
-let { fromJS, List } = require('immutable')
 let util = require('util')
 
 const { encodeChange, decodeChange } = require('./columnar')
@@ -13,16 +12,9 @@ function decodeChanges(binaryChanges) {
     for (let change of decodeChange(binaryChange)) decoded.push(change)
   }
   //console.log("CHANGES",util.inspect(decoded, {showHidden: false, depth: null}))
-  return fromJS(decoded)
+  return decoded
 }
 
-
-function toJS(obj) {
-  if (List.isList(obj)) {
-    return obj.toJS()
-  }
-  return obj
-}
 
 let init = () => {
   return { state: Backend.State.new(), clock: {}, frozen: false };
@@ -30,6 +22,7 @@ let init = () => {
 
 let clean = (backend) => {
   if (backend.frozen) {
+    //throw new Error('do not fork')
     let state = backend.state.forkAt(backend.clock)
     backend.state = state
     backend.clock = state.getClock()
@@ -58,30 +51,19 @@ let loadChanges = (backend,changes) => {
 
 let applyLocalChange = (backend,request) => {
   //console.log("LOCAL REQUEST",util.inspect(request, {showHidden: false, depth: null}))
-  return mutate(backend, (b) => b.applyLocalChange(toJS(request)));
-}
-
-let merge = (backend1,backend2) => {
-  return mutate(backend1, (b) => b.merge(clean(backend2)));
+  return mutate(backend, (b) => b.applyLocalChange(request));
 }
 
 let getClock = (backend) => {
-  return fromJS(backend.clock);
-}
-
-let getHistory = (backend) => {
-  let history = clean(backend).getHistory();
-  return history
+  return backend.clock;
 }
 
 let getUndoStack = (backend) => {
-  let stack = clean(backend).getUndoStack();
-  return fromJS(stack)
+  return clean(backend).getUndoStack();
 }
 
 let getRedoStack = (backend) => {
-  let stack = clean(backend).getRedoStack();
-  return fromJS(stack)
+  return clean(backend).getRedoStack();
 }
 
 let getPatch = (backend) => clean(backend).getPatch()
@@ -89,10 +71,9 @@ let getChanges = (backend,other) => clean(backend).getChanges(clean(other)).map(
 let getChangesForActor = (backend,actor) => clean(backend).getChangesForActor(actor).map(encodeChange)
 let getMissingChanges = (backend,clock) => clean(backend).getMissingChanges(clock).map(encodeChange)
 let getMissingDeps = (backend) => clean(backend).getMissingDeps()
-let _elemIds = (backend,obj_id) => clean(backend)._elemIds(obj_id)
 
 module.exports = {
   init, applyChanges, applyLocalChange, getPatch,
-  getChanges, getChangesForActor, getMissingChanges, getMissingDeps, merge, getClock,
-  getHistory, getUndoStack, getRedoStack, loadChanges, _elemIds
+  getChanges, getChangesForActor, getMissingChanges, getMissingDeps,
+  getClock, getUndoStack, getRedoStack, loadChanges
 }

--- a/automerge-backend-wasm/index.js
+++ b/automerge-backend-wasm/index.js
@@ -67,13 +67,12 @@ let getRedoStack = (backend) => {
 }
 
 let getPatch = (backend) => clean(backend).getPatch()
-let getChanges = (backend,other) => clean(backend).getChanges(clean(other)).map(encodeChange)
+let getChanges = (backend,clock) => clean(backend).getChanges(clock).map(encodeChange)
 let getChangesForActor = (backend,actor) => clean(backend).getChangesForActor(actor).map(encodeChange)
-let getMissingChanges = (backend,clock) => clean(backend).getMissingChanges(clock).map(encodeChange)
 let getMissingDeps = (backend) => clean(backend).getMissingDeps()
 
 module.exports = {
   init, applyChanges, applyLocalChange, getPatch,
-  getChanges, getChangesForActor, getMissingChanges, getMissingDeps,
+  getChanges, getChangesForActor, getMissingDeps,
   getClock, getUndoStack, getRedoStack, loadChanges
 }


### PR DESCRIPTION
Intended to go with automerge/automerge@6c17526cec9712488e8820083bf0cbc5a36fc71e and preceding commits. These commits allow the backend to be swapped out, remove dependency on immutability, and clean up the API so that code outside of the backend doesn't reach directly into backend internals.

Currently the tests still throw a lot of errors like:

    "serde_json error: invalid type: null, expected a map at line 1 column 4"

Not sure where they are coming from as it's not showing a stack trace.